### PR TITLE
Unit tests and small fix to run on node 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *~
 *.log
 node_modules
+.nyc_output

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const request = require("jsonrequest");
 
 /**

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An http://ipinfo.io NodeJS wrapper.",
   "main": "lib/index.js",
   "scripts": {
-    "test": "node test"
+    "test": "nyc ava"
   },
   "repository": {
     "type": "git",
@@ -27,7 +27,11 @@
   "dependencies": {
     "jsonrequest": "^4.1.3"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "ava": "^0.17.0",
+    "nyc": "^10.0.0",
+    "pify": "^2.3.0"
+  },
   "files": [
     "bin/",
     "app/",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.3",
   "description": "An http://ipinfo.io NodeJS wrapper.",
   "main": "lib/index.js",
+  "engines": {
+    "node": ">=4"
+  },
   "scripts": {
     "test": "nyc ava"
   },

--- a/test.js
+++ b/test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+// npm
+import pify from 'pify'
+import test from 'ava'
+
+// self
+import fnImp from './'
+
+const fn = pify(fnImp)
+
+const expected = ['ip', 'hostname', 'city', 'region', 'country', 'loc', 'org', 'postal']
+
+test('self', async t => {
+  const result = await fn()
+  t.plan(2 * expected.length)
+  for (let r in result) {
+    t.truthy(result[r])
+    t.truthy(expected.indexOf(r) !== -1)
+  }
+})
+
+test('google', async t => {
+  const result = await fn('8.8.8.8')
+  t.is(result.ip, '8.8.8.8')
+  t.is(result.hostname, 'google-public-dns-a.google.com')
+  t.is(result.city, 'Mountain View')
+  t.is(result.region, 'California')
+  t.is(result.country, 'US')
+  t.is(result.loc, '37.3860,-122.0838')
+  t.is(result.org, 'AS15169 Google Inc.')
+  t.is(result.postal, '94035')
+})
+
+test('google org', async t => {
+  const result = await fn('8.8.8.8/org')
+  t.is(result.trim(), 'AS15169 Google Inc.')
+})
+
+test('google orga', async t => {
+  // FIXME: should probably fail
+  // or at least not return the string 'undefined\n'
+  const result = await fn('8.8.8.8/orga')
+  t.is(result, 'undefined\n')
+})
+
+test('not google', async t => {
+  // FIXME: should probably fail
+  // or at least not return the string 'Please provide a valid IP address'
+  const result = await fn('8.8.8')
+  t.is(result, 'Please provide a valid IP address')
+})
+
+test('google with token', async t => {
+  // FIXME: should probably fail
+  const result = await fn('8.8.8.8', 'a-token-no-really')
+  t.is(result.ip, '8.8.8.8')
+  t.is(result.hostname, 'google-public-dns-a.google.com')
+  t.is(result.city, 'Mountain View')
+  t.is(result.region, 'California')
+  t.is(result.country, 'US')
+  t.is(result.loc, '37.3860,-122.0838')
+  t.is(result.org, 'AS15169 Google Inc.')
+  t.is(result.postal, '94035')
+})


### PR DESCRIPTION
Use [ava](https://github.com/avajs/ava) and [nyc](https://github.com/istanbuljs/nyc) for unit tests and code coverage respectively.

Also made the module compatible with node 4.x with a tiny change ('use strict').

Fixed it so I could use [cli-sunset](https://github.com/IonicaBizau/cli-sunset) with my old node.
