### PR TITLE
fix invalid URL format when token is used with no type info

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ const ipInfo = module.exports = function (type, token, callback) {
 
     if(typeof token === "string") {
         if (!type) {
-            url = ipInfo.HOSTNAME_SSL  + "/json" + ipInfo.TOKEN_PREFIX + token
+            url = ipInfo.HOSTNAME_SSL  + "json" + ipInfo.TOKEN_PREFIX + token
         } else if (ipInfo.IP_REGEX.test(type)) {
             url = ipInfo.HOSTNAME_SSL  + type + "/json" + ipInfo.TOKEN_PREFIX + token
         } else {


### PR DESCRIPTION
`url = ipInfo.HOSTNAME_SSL  + "/json" + ipInfo.TOKEN_PREFIX + token` 
creates `https://ipinfo.io//json` 
because `ipInfo.HOSTNAME_SSL = "https://ipinfo.io/";`
which leads to `Cannot GET //json` etc.

Only thing changed is removing the extra `/`

Hope it's OK I created the pull request directly as it's only a tiny change.

Best regards,
Florian